### PR TITLE
fix unexpected indent in gallery view

### DIFF
--- a/templates/views/gallery.jade
+++ b/templates/views/gallery.jade
@@ -10,7 +10,7 @@ block content
 	//- p.lead Please follow us for updates to the demo site.
 
 	if galleries.length
-		
+
 		each gallery, i in galleries
 			if i
 				hr


### PR DESCRIPTION
This lil indent was wrecking the whole gallery. I might suggest adding some sort of whitespace checking to your editor. But perhaps whitespace is not your concern. :see_no_evil: 

At any rate this fixes the gallery view.

P.S. the new demo site is looking fresh! :+1: 